### PR TITLE
ARCH-04 — IAM foundation (Keycloak + Casbin)

### DIFF
--- a/ops/docs/adr/adr-0002-iam-foundation.md
+++ b/ops/docs/adr/adr-0002-iam-foundation.md
@@ -1,0 +1,48 @@
+# ADR-0002: IAM Foundation — Keycloak (AuthN) + Casbin (AuthZ)
+
+Status
+- Proposed
+
+Context
+- We need a portable, self-hostable IAM foundation to gate all API work. Requirements include: multi-tenant readiness, standards-based SSO (OIDC/OAuth2), service accounts, fine-grained authorization, auditable decisions, and minimal operational overhead.
+- Per ARCH-04 — IAM and Prompt Management, we prefer full control and fewer moving parts vs. managed services.
+
+Decision
+- Identity Provider (AuthN): Keycloak (self-host). Use OIDC/OAuth2 with discovery (/.well-known/openid-configuration) and JWKS for token verification.
+- Authorization (AuthZ): Casbin (embedded library) for application-level policy enforcement. Policies versioned alongside code; simple to operate without an external PDP.
+
+Rationale
+- Control: Self-hosted Keycloak and embedded Casbin give us full control over identity, federation, and policies without external dependencies.
+- Standards: OIDC/OAuth2 provide broad compatibility and portability; Casbin supports RBAC/ABAC models and multiple policy backends.
+- Simplicity: Avoids introducing and operating an additional PDP service (e.g., Cerbos/OPA) at Phase 1, reducing latency and ops complexity.
+
+Consequences
+- Operational ownership of Keycloak (backup, upgrades, HA). We will provide Terraform/scripts in a future phase; Phase 1 may run a single-node dev/test cluster.
+- Policy lifecycle: Policies live with the app; we must enforce rigorous review/testing (contract tests) and audit logs for decisions.
+- Future evolution: If cross-service policy centralization becomes necessary, we can introduce a PDP later and adapt the authorization port.
+
+Implementation Guidance
+- Token verification via OIDC discovery and JWKS; verify signature, exp, nbf, aud, iss; require tenant context (org/realm) and subject claims.
+- Route guards call an authorization service which delegates to Casbin enforce(subject, resource, action, context). Policies stored in repo; environment selects policy set.
+- Audit every allow/deny decision with correlation ID; emit structured logs and traces.
+- Contracts: Define JSON Schemas for token claims and PDP request/response. Validate in CI and in non-prod at runtime.
+
+Portability
+- No vendor-specific IdP APIs in application code. Interact via standard OIDC flows and JWKS.
+- Authorization port isolates Casbin behind an interface so we can swap to PDP if needed.
+
+Decision Drivers
+- Full control, low latency, minimal moving parts; compliance readiness and auditability.
+
+Alternatives Considered
+- ZITADEL + Cerbos: managed/self-managed IdP with external PDP; higher ops cost, strong decoupling.
+- Keycloak + Cerbos/OPA: more components to run; better centralization at scale, not needed in Phase 1.
+
+References
+- Tracker: ARCH-04 — IAM and Prompt Management (Issue #4)
+- Canonical rules: AI-agent conventions, documentation best practices, branching policy
+
+Acceptance Criteria (for this ADR to be "Approved")
+- Linked design spec (iam-foundation-spec.md)
+- Contracts present for token claims and authz requests
+- DoR gates documented for all API PRs

--- a/ops/docs/contracts/iam/authz-request.schema.json
+++ b/ops/docs/contracts/iam/authz-request.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://max-ai.platform/iam/authz-request.schema.json",
+  "title": "Authorization Request",
+  "type": "object",
+  "required": ["subject", "resource", "action"],
+  "properties": {
+    "subject": {
+      "type": "object",
+      "required": ["id", "tenant"],
+      "properties": {
+        "id": {"type": "string"},
+        "tenant": {"type": "string"},
+        "roles": {"type": "array", "items": {"type": "string"}},
+        "groups": {"type": "array", "items": {"type": "string"}},
+        "scopes": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": true
+    },
+    "resource": {
+      "type": "object",
+      "required": ["type", "id"],
+      "properties": {
+        "type": {"type": "string"},
+        "id": {"type": "string"},
+        "ownerTenant": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "action": {"type": "string"},
+    "context": {"type": "object", "additionalProperties": true}
+  },
+  "additionalProperties": false
+}

--- a/ops/docs/contracts/iam/authz-response.schema.json
+++ b/ops/docs/contracts/iam/authz-response.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://max-ai.platform/iam/authz-response.schema.json",
+  "title": "Authorization Response",
+  "type": "object",
+  "required": ["decision"],
+  "properties": {
+    "decision": {"type": "string", "enum": ["allow", "deny"]},
+    "reason": {"type": "string"},
+    "policyRef": {"type": "string"},
+    "obligations": {"type": "object", "additionalProperties": true}
+  },
+  "additionalProperties": false
+}

--- a/ops/docs/contracts/iam/keycloak-token-claims.schema.json
+++ b/ops/docs/contracts/iam/keycloak-token-claims.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://max-ai.platform/iam/keycloak-token-claims.schema.json",
+  "title": "Keycloak Token Claims",
+  "type": "object",
+  "required": ["iss", "sub", "aud", "exp", "iat", "tenant"],
+  "properties": {
+    "iss": {"type": "string", "format": "uri"},
+    "sub": {"type": "string"},
+    "aud": {"oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}]},
+    "exp": {"type": "integer", "minimum": 0},
+    "nbf": {"type": "integer", "minimum": 0},
+    "iat": {"type": "integer", "minimum": 0},
+    "jti": {"type": "string"},
+    "tenant": {"type": "string", "description": "Tenant/realm or org identifier"},
+    "scope": {"type": "string"},
+    "roles": {"type": "array", "items": {"type": "string"}},
+    "groups": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": true
+}

--- a/ops/docs/design/iam/iam-foundation-spec.md
+++ b/ops/docs/design/iam/iam-foundation-spec.md
@@ -1,0 +1,66 @@
+# IAM Foundation Spec — Keycloak + Casbin
+
+Tracker: ARCH-04 — IAM and Prompt Management (Issue #4)
+References: ADR-0002 (iam foundation), docs/design/adapter-contracts.md, docs/adr/*
+
+Purpose
+Define the IAM foundation to gate all API work with AuthN (OIDC) and AuthZ (Casbin), ensuring portability, auditability, and CI enforcement.
+
+Scope
+- Identity model (tenants, users, service accounts, roles/permissions)
+- Ports/adapters: IdP (Keycloak), AuthZ (Casbin)
+- Middleware chain and cross-cutting concerns (validation, audit, telemetry)
+- Contracts (JSON Schemas) for token claims and authorization requests
+- Definition of Ready gates and CI checks
+
+Canonical identity and authorization model
+- Tenant: organization/workspace context; maps to Keycloak realm or client-scoped role sets
+- Subject: user or service account; includes subject ID, tenant ID, roles/groups, scopes
+- Resource: domain object identifier and type
+- Action: verb (read, write, update, delete, admin, etc.)
+- Context: optional attributes (ownership, record tenant, flags)
+
+Ports and adapters
+- AuthN Port (IdP):
+  - Verify JWT from Keycloak via discovery and JWKS; validate iss/aud/exp/nbf and required claims (sub, tenant)
+  - Extract subject context (sub, tenant, roles/groups, scopes)
+- AuthZ Port (Policy):
+  - Interface: allow = enforce(subject, resource, action, context)
+  - Default adapter: Casbin with RBAC model; policies versioned in repo; per-tenant policy sets supported
+
+Middleware sequence (request lifecycle)
+1) Request ID and correlation context
+2) Security headers and CORS
+3) Rate limiting (per user/tenant/service account)
+4) AuthN: OIDC token verification (fail-closed)
+5) AuthZ: enforce() via Casbin; deny with 403 and audit event
+6) JSON Schema validation (non-prod runtime; CI always)
+7) Handler
+8) Audit log emission (subject, resource, action, decision, reason) and telemetry spans
+
+Contracts (summary; see schemas in ops/docs/contracts/iam)
+- keycloak-token-claims.schema.json: issuer, audience, subject, tenant, roles/groups, scopes, expiry
+- authz-request.schema.json: subject, resource, action, context
+- authz-response.schema.json: decision (allow/deny), reason, policyRef, obligations
+
+Definition of Ready (IAM gates for any API PR)
+- OIDC token verification enabled with Keycloak discovery and JWKS
+- Authorization check via Casbin enforce() for protected resources
+- Input/Output schemas present and validated (runtime in non-prod; CI always)
+- Structured logs with correlation ID; audit for sensitive operations
+- CI: ESLint warnings-as-errors, coverage >=95%, contract tests green
+
+Test strategy (linked, separate doc)
+- Unit tests for middleware and policy checks
+- Contract tests for token claims and authz req/resp against JSON Schemas
+- Integration tests with sample protected route
+
+Non-functional requirements
+- Performance: <2ms median overhead per request for AuthZ; <10ms p95 for AuthN (cached JWKS)
+- Reliability: fail-closed for invalid tokens; clear error types; policy reload safety
+- Security: no secrets in logs; tenant isolation; minimal scopes for service accounts
+
+Open questions / Phase transitions
+- Exact tenant mapping to Keycloak realms vs client roles (evaluate during integration)
+- Policy storage backend for Casbin (file vs DB) per environment
+- Future PDP introduction (Cerbos/OPA) if cross-service centralization is needed

--- a/ops/rules/coding-standards.md
+++ b/ops/rules/coding-standards.md
@@ -3,6 +3,13 @@
 Purpose
 Provide clear, enforceable guidance so coders (human and AI) produce small, testable, maintainable code that fits our architecture and CI gates.
 
+IAM foundation (Keycloak + Casbin) — Definition of Ready gates (MANDATORY)
+- AuthN: All protected endpoints must verify OIDC JWTs using OIDC discovery and JWKS from Keycloak. Validate iss/aud/exp/nbf and required claims (sub, tenant).
+- AuthZ: All protected endpoints must enforce authorization via Casbin (enforce(subject, resource, action, context)). Policies must live in-repo and be reviewed in PRs.
+- Contracts: JSON Schemas must exist and be referenced for token claims and authz request/response. Contract tests run in CI; runtime validation enabled in non-prod.
+- Observability: Structured logs with correlation IDs; emit audit event on allow/deny decisions for sensitive actions.
+- CI gates: eslint --max-warnings 0, tests + coverage ≥95% for changed code, contract tests green. PRs may not introduce new warnings.
+
 General principles
 - Single Responsibility: each module/function/class does one thing; prefer composition over large multi‑purpose units.
 - Small, testable units: design functions with explicit inputs/outputs; avoid hidden global state; maximize pure logic.

--- a/ops/rules/task-completion-workflows.md
+++ b/ops/rules/task-completion-workflows.md
@@ -11,23 +11,28 @@ When a dev completes implementation:
    - Add one: action:qa-review or action:qa-test
    - Add status:needs-qa
    - Comment with a one-paragraph instruction for QA (scope, risks, what to verify)
-2. **AUTO-RUN quality gates**:
-   ```bash
-   npm run lint --fix
-   npm run build
-   npm run test
-   npm run test:coverage  # Must be ≥95%
-   ```
-2. **AUTO-COMMIT** if all gates pass:
-   ```bash
-   git add .
-   git commit -m "feat(area): HAKIM-N short description"
-   git push origin work/dev/HAKIM-N-slug
-   ```
-3. **AUTO-CREATE PR** linking to issue and spec
-4. **AUTO-TRANSITION** issue state to status:needs-qa with comment: "✅ Dev complete — ready for QA"
-5. **AUTO-REASSIGN** to QA seat and keep role:qa label for routing
-6. **IMMEDIATELY** query for next assigned issue
+2. Ensure IAM DoR gates are present on affected endpoints:
+   - OIDC token verification using Keycloak discovery/JWKS
+   - Casbin authorization checks for protected resources
+   - JSON Schema contracts referenced and tests added
+   - Structured logs + audit events for sensitive actions
+3. **AUTO-RUN quality gates**:
+```bash
+npm run lint --fix
+npm run build
+npm run test
+npm run test:coverage  # Must be ≥95%
+```
+4. **AUTO-COMMIT** if all gates pass:
+```bash
+git add .
+git commit -m "feat(area): HAKIM-N short description"
+git push origin work/dev/HAKIM-N-slug
+```
+5. **AUTO-CREATE PR** linking to issue and spec
+6. **AUTO-TRANSITION** issue state to status:needs-qa with comment: "Dev complete — ready for QA"
+7. **AUTO-REASSIGN** to QA seat and keep role:qa label for routing
+8. **IMMEDIATELY** query for next assigned issue
 
 ### Architect Task Completion  
 When architect completes spec/design:


### PR DESCRIPTION
This PR adds the IAM foundation docs and governance for ARCH-04 — IAM and Prompt Management.\n\nIncludes:\n- ADR-0002 selecting Keycloak (AuthN) + Casbin (AuthZ)\n- IAM foundation spec (ports/adapters, middleware, NFRs)\n- JSON Schemas for token claims and authz req/resp\n- Governance updates enforcing IAM DoR gates in coding standards and workflows\n\nAcceptance criteria:\n- ADR linked and spec present\n- Contracts present for token claims and authorization\n- DoR gates documented and enforceable in CI/checklists\n\nReferences:\n- ops/docs/adr/adr-0002-iam-foundation.md\n- ops/docs/design/iam/iam-foundation-spec.md\n- ops/docs/contracts/iam/*.schema.json\n\nFixes #3