### PR TITLE
Assignment-of-record policy + readiness-gated triage + seat routing templates

### DIFF
--- a/ops/docs/ops-template/rules/scope-control-and-triage.md
+++ b/ops/docs/ops-template/rules/scope-control-and-triage.md
@@ -27,12 +27,12 @@ Examples:
 
 Hakim Platform ops:
 ```
-PROJECT_OPS_DIR=$HOME/repos/hakim/hakim-platform/ops SEAT=dev.avery-kim $HOME/repos/ops-template/scripts/list-issues.sh
+PROJECT_OPS_DIR=$HOME/repos/hakim/hakim-platform/ops SEAT=dev.avery-kim READINESS_LABEL="status:ready" $HOME/repos/ops-template/scripts/list-issues.sh
 ```
 
 MaxAI Platform ops:
 ```
-PROJECT_OPS_DIR=$HOME/repos/max-ai/platform/ops SEAT=dev.avery-kim $HOME/repos/ops-template/scripts/list-issues.sh
+PROJECT_OPS_DIR=$HOME/repos/max-ai/platform/ops SEAT=dev.avery-kim READINESS_LABEL="status:ready" $HOME/repos/ops-template/scripts/list-issues.sh
 ```
 
 Optional assignee routing (use when organization prefers assignee-based triage):

--- a/ops/docs/ops-template/rules/task-completion-workflows.md
+++ b/ops/docs/ops-template/rules/task-completion-workflows.md
@@ -103,9 +103,9 @@ Auto-escalate to humans only when:
 4) Always leave a short progress comment on the issue before switching context.
 
 ### Quick commands
-- Show my issues (assigned to me):
-  PROJECT_OPS_DIR=<ops> SEAT=<role.name> $HOME/repos/ops-template/scripts/list-issues.sh
+- Show my issues (ready for my seat):
+  PROJECT_OPS_DIR=<ops> SEAT=<role.name> READINESS_LABEL="status:ready" $HOME/repos/ops-template/scripts/list-issues.sh
 - Auto next (continue if only one obvious option, else present choices):
-  PROJECT_OPS_DIR=<ops> SEAT=<role.name> $HOME/repos/ops-template/scripts/auto-next.sh
+  PROJECT_OPS_DIR=<ops> SEAT=<role.name> READINESS_LABEL="status:ready" $HOME/repos/ops-template/scripts/auto-next.sh
 - Reload seat prompt:
   PROJECT_OPS_DIR=<ops> SEAT=<role.name> $HOME/repos/ops-template/scripts/reload-seat.sh

--- a/ops/docs/ops-template/rules/tasks-and-concurrency.md
+++ b/ops/docs/ops-template/rules/tasks-and-concurrency.md
@@ -14,6 +14,14 @@ Issue conventions
 - Labels: role (team_lead/dev/qa), phase (phase-1/2/3), area (ordering/iam/lab/etc.), seat:<seat> for label-based assignment.
 - Cross-links: PRs must include Fixes #<N> (client) or Refs org/hakim-platform-ops#<N> (ops).
 
+Assignment of record
+- Seat label is authoritative: use seat:<role.seat> to route work. Agents must only pick issues with their seat label.
+- Readiness gate required: status:ready must be present for an agent to pick an issue. Use status:triage or status:blocked otherwise.
+- Assignee optional: GH “Assignee” may be used for visibility, but agents must key off seat labels for routing.
+- Comments are non-authoritative: use comments for context/instructions; do not rely on them for routing.
+- Priority labels: use priority:P0, priority:P1, etc. Sorting and triage should respect these.
+- Handoff: when Team Lead is done coordinating, flip seat:team_lead.<seat> -> seat:dev.<seat> and keep status:ready if applicable.
+
 Directories (optional, for templates only)
 - tracker/specs — specifications (one per tracker ID)
 - tracker/tasks — leave empty (no local tasks); keep only templates if needed

--- a/ops/docs/ops-template/templates/agent-task.md
+++ b/ops/docs/ops-template/templates/agent-task.md
@@ -5,6 +5,11 @@ Owner: <agent-seat>
 State: todo | in-progress | needs-review | approved | done
 Related: <links to specs/ADRs/designs>
 
+Seat routing (required)
+- Next seat: <role.seat>
+- Labels to add in tracker: `seat:<role.seat>`, `status:ready` (when ready to pick)
+- Priority: `priority:P0|P1|P2`
+
 Summary
 <what the agent is doing and why>
 

--- a/ops/docs/ops-template/templates/dev-task-with-arch-constraints.md
+++ b/ops/docs/ops-template/templates/dev-task-with-arch-constraints.md
@@ -88,6 +88,12 @@
 - [ ] Implement contract tests per adapter specification
 - [ ] Run JSON Schema validation in CI pipeline
 
+## Seat routing (required)
+
+- Next seat: <role.seat>
+- Add labels in tracker: `seat:<role.seat>`, `status:ready`
+- When handing off from Team Lead to Dev, replace `seat:team_lead.<seat>` with `seat:dev.<seat>` and keep `status:ready` if appropriate
+
 ## 🧪 **Testing Strategy**
 
 ### Unit Tests (≥95% Coverage)


### PR DESCRIPTION
This PR syncs canonical ops-template updates:\n- Adds 'Assignment of record' policy (seat labels authoritative, status:ready gating)\n- Updates triage examples to include READINESS_LABEL=status:ready\n- Updates templates to require seat routing (seat:<role.seat>, status:ready)