### PR TITLE
DEV-ONB-02: Template selection step (Portal UI)

### DIFF
--- a/client/web/src/app/onboarding/__tests__/steps.spec.tsx
+++ b/client/web/src/app/onboarding/__tests__/steps.spec.tsx
@@ -6,6 +6,8 @@ import CustomizeStep from '../customize/page';
 import PlanStep from '../plan/page';
 import { useOnboardingStore } from '../store';
 
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+
 describe('onboarding steps', () => {
   beforeEach(() => {
     useOnboardingStore.setState({
@@ -23,8 +25,8 @@ describe('onboarding steps', () => {
   });
 
   it('TemplatesStep marks template selected', () => {
-    const { getByText } = render(<TemplatesStep />);
-    fireEvent.click(getByText('Select Template'));
+    const { getByLabelText } = render(<TemplatesStep />);
+    fireEvent.click(getByLabelText('select-welcome-bot'));
     expect(useOnboardingStore.getState().templateSelected).toBe(true);
   });
 

--- a/client/web/src/app/onboarding/__tests__/templates.ui.spec.tsx
+++ b/client/web/src/app/onboarding/__tests__/templates.ui.spec.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import TemplatesStep from '../templates/page';
+import { useOnboardingStore } from '../store';
+
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+
+describe('templates UI', () => {
+  beforeEach(() => {
+    useOnboardingStore.setState({
+      clientComplete: true,
+      templateSelected: false,
+      customizeComplete: false,
+      planReady: false,
+    });
+  });
+
+  it('renders templates and selects one', () => {
+    const { getByLabelText } = render(<TemplatesStep />);
+    const selectBtn = getByLabelText('select-welcome-bot');
+    fireEvent.click(selectBtn);
+    expect(useOnboardingStore.getState().templateSelected).toBe(true);
+    expect(useOnboardingStore.getState().templateData).toEqual(
+      expect.objectContaining({ templateId: 'welcome-bot' })
+    );
+  });
+});

--- a/client/web/src/app/onboarding/templates/page.tsx
+++ b/client/web/src/app/onboarding/templates/page.tsx
@@ -1,22 +1,35 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useOnboardingStore } from "../store";
+import { TEMPLATES, TemplateInfo } from "./templates.data";
 
 export default function TemplatesStep() {
   const setTemplateSelected = useOnboardingStore((s) => s.setTemplateSelected);
+  const router = useRouter();
+
+  function chooseTemplate(t: TemplateInfo) {
+    setTemplateSelected(true, { templateId: t.id, templateName: t.name });
+    router.push("/onboarding/customize");
+  }
+
   return (
     <main style={{ padding: 24 }}>
       <h1>Onboarding: Templates</h1>
-      <p>Select a template from the registry.</p>
-      <div style={{ display: "flex", gap: 12, marginTop: 16 }}>
-        <button
-          onClick={() => setTemplateSelected(true, { template: "starter" })}
-        >
-          Select Template
-        </button>
-        <Link href="/onboarding/customize">Next: Customize →</Link>
-      </div>
+      <p>Choose a template to get started. You can customize it on the next step.</p>
+      <ul style={{ listStyle: "none", padding: 0, marginTop: 16, display: "grid", gap: 12 }}>
+        {TEMPLATES.map((t) => (
+          <li key={t.id} style={{ border: "1px solid #ddd", borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <div>
+                <div style={{ fontWeight: 600 }}>{t.name}</div>
+                <div style={{ color: "#555" }}>{t.description}</div>
+              </div>
+              <button onClick={() => chooseTemplate(t)} aria-label={`select-${t.id}`}>Select</button>
+            </div>
+          </li>
+        ))}
+      </ul>
     </main>
   );
 }

--- a/client/web/src/app/onboarding/templates/templates.data.ts
+++ b/client/web/src/app/onboarding/templates/templates.data.ts
@@ -1,0 +1,12 @@
+export type TemplateInfo = {
+  id: string;
+  name: string;
+  description: string;
+  category?: string;
+};
+
+export const TEMPLATES: TemplateInfo[] = [
+  { id: 'welcome-bot', name: 'Welcome Bot', description: 'Greets new contacts and captures essentials', category: 'starter' },
+  { id: 'support-intake', name: 'Support Intake', description: 'Collects support details and triages', category: 'support' },
+  { id: 'appointment-scheduler', name: 'Appointment Scheduler', description: 'Schedules calls and sends reminders', category: 'scheduling' },
+];


### PR DESCRIPTION
Implements the template selection page for #34 within the onboarding wizard.\n\nScope\n- Templates registry (static) with id/name/description\n- TemplatesStep lists templates and selects to proceed to Customize\n- Store updated with templateId/name; guards unchanged\n- Tests: UI selection and updated step suite\n\nNotes\n- Builds on the existing wizard shell (#23) and stacks on that branch\n\nRefs #34