### PR TITLE
ARCH-09 — LLM Provider & Content Automation: ADR accepted + extreme-detail spec

### DIFF
--- a/ops/docs/adr/adr-0006-llm-provider-agnostic.md
+++ b/ops/docs/adr/adr-0006-llm-provider-agnostic.md
@@ -1,19 +1,23 @@
 # ADR-0006: LLM Provider Agnostic Abstraction
 
-Status: Proposed
+Status: Accepted
+Date: 2025-10-06
+Deciders: Architecture Team
 
-Context
-We will use LLMs to prepare prompts, flow specs, webhook mappings, and other client-specific content. We must remain provider-agnostic although OpenRouter is the default.
+## Context
+We will use LLMs to prepare prompts, flow specs, webhook mappings, and other client-specific content. We must remain provider-agnostic although OpenRouter is the default, and enforce controls for validation, provenance, and cost.
 
-Decision
+## Decision
 - Introduce ILlmPort and adapters (OpenRouter first; allow direct providers later)
-- Store generated artifacts as drafts; validate via schemas/contract tests before activation
-- Track provenance (model, params, prompt hash); require human approval for activation
+- Store generated artifacts as drafts; validate via JSON Schemas/contract tests in CI and non-prod runtime before activation
+- Track provenance (model, params, prompt hash, tokens, cost); require human approval for activation
+- Enforce policy/guardrails (prohibited content, PII/PHI filters), determinism for schema-bound tasks, and per-tenant budget controls
 
-Consequences
-- Flexibility to switch models/providers per task
-- Better governance and reproducibility for generated content
+## Consequences
+- Flexibility to switch models/providers per task; stronger governance and reproducibility
+- Predictable cost and safer automation via validation and policy enforcement
 
-References
-- docs/design/llm-and-automation.md
-- docs/design/ports-and-adapters.md
+## References
+- ops/docs/design/llm-provider-automation-spec.md
+- ops/docs/design/llm-and-automation.md
+- ops/docs/design/ports-and-adapters.md

--- a/ops/docs/design/llm-provider-automation-spec.md
+++ b/ops/docs/design/llm-provider-automation-spec.md
@@ -1,0 +1,62 @@
+# LLM Provider and Content Automation — Extreme Detail Spec
+
+Purpose
+Define a provider-agnostic LLM integration and content automation pipeline for generating/editing prompts, flow specs, webhook mappings, and deployment artifacts with strict controls, validation, and observability.
+
+Ports (interfaces)
+- ILlmPort: generate({task, input, modelHints, policy}) → {content, tokens, modelId}
+- IContentValidator: validate({type, content}) → {ok, errors[]}
+- IContentRegistry: saveDraft({type, content, meta}) → draftId; promote(draftId) → versionId
+- IProvenanceStore: record({artifactId, modelId, params, promptHash, cost, tokens})
+
+Artifacts (types)
+- prompt_template, prompt_instance
+- flow_spec (JSON Schema governed)
+- webhook_mapping
+- deployment_plan (links to template deployment)
+
+Policies & safety
+- Guardrails: prohibited content categories, PII/PHI leakage filters
+- Determinism where required: temperature <= 0.2 for schema-bound generation
+- Rate/Cost controls: per-tenant quotas; budget alerts via metrics
+
+Workflow
+1) Authoring request (human → API): choose artifact type, inputs, constraints
+2) ILlmPort runs with modelHints; retries on provider errors with backoff
+3) IContentValidator validates against canonical JSON Schemas
+4) Save as draft (IContentRegistry) with provenance recorded; human review required
+5) Promote to active only after contract tests pass in CI/non-prod runtime
+
+Contracts (JSON Schemas)
+- Reuse existing schemas (prompt-template.schema.json, prompt-instance.schema.json, flow.schema.json)
+- Add webhook-mapping.schema.json (provider→internal mapping rules)
+
+Observability
+- Logs: artifact_type, artifact_id, tenant_id, model_id, tokens, cost_cents, correlation_id
+- Metrics: llm_requests_total{provider,model}, llm_tokens_total{direction}, llm_failures_total{reason}, content_validation_failures_total
+- Traces: span around ILlmPort calls; annotate provider/model, tokens
+
+NFRs
+- P95 generation latency < 3s for 4k-token prompts; retry budget ≤ 2
+- Validation failure rate < 2% for schema-bound tasks in non-prod
+- Cost guard: enforce per-tenant budgets with alerting
+
+Error taxonomy
+- 400.validation_error | 422.policy_violation
+- 429.rate_limited
+- 502.provider_error_{provider}
+
+Test strategy
+- Unit: ILlmPort adapter mock; policy filters; schema validation; provenance recording
+- Integration: end-to-end draft → CI contract tests → promote
+- Contract: schema validation for each artifact type; negative tests
+
+Acceptance criteria
+- ILlmPort abstraction with at least one provider adapter (OpenRouter)
+- Draft → promote pipeline implemented with validation and provenance
+- Observability and budget controls in place; basic guardrails enforced
+
+References
+- ADR-0006 — LLM Provider Agnostic Abstraction
+- ops/docs/design/impl/phase-1/prompt-svc.md
+- ops/docs/design/impl/phase-1/template-deployment.md


### PR DESCRIPTION
Summary
Accept ADR-0006 (LLM provider agnostic) and add an extreme-detail spec for provider-agnostic content automation (prompts, flows, webhook mappings, deployment artifacts) with validation, provenance, policy guardrails, and observability.

Files
- ops/docs/adr/adr-0006-llm-provider-agnostic.md (Accepted + detailed decision)
- ops/docs/design/llm-provider-automation-spec.md

Acceptance criteria
- ILlmPort abstraction with at least one adapter (OpenRouter) planned
- Draft → promote pipeline governed by JSON Schemas + contract tests
- Provenance and budget controls; guardrails for PII/PHI; observability metrics/traces

Links
- Refs #8 (ARCH-09 — LLM Provider and Content Automation)
- Related: Prompt Service, Template Deployment specs
